### PR TITLE
perf: reduce allocations in assign ops

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -572,8 +572,8 @@ impl<'a, 'b> Mul<&'b Fp> for &'a Fp {
     }
 }
 
-impl_binops_additive!(Fp, Fp);
-impl_binops_multiplicative!(Fp, Fp);
+impl_binops_additive!(Fp, Fp, fff::Field);
+impl_binops_multiplicative!(Fp, Fp, fff::Field);
 
 impl fff::Field for Fp {
     fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
@@ -626,22 +626,23 @@ impl fff::Field for Fp {
     }
 
     fn double(&mut self) {
-        *self += *self;
+        unsafe { blst_fp_add(&mut self.0, &self.0, &self.0) };
     }
 
     fn negate(&mut self) {
         *self = -&*self;
     }
+
     fn add_assign(&mut self, other: &Self) {
-        *self += other;
+        unsafe { blst_fp_add(&mut self.0, &self.0, &other.0) };
     }
 
     fn sub_assign(&mut self, other: &Self) {
-        *self -= other;
+        unsafe { blst_fp_sub(&mut self.0, &self.0, &other.0) };
     }
 
     fn mul_assign(&mut self, other: &Self) {
-        *self = self.mul(other)
+        unsafe { blst_fp_mul(&mut self.0, &self.0, &other.0) };
     }
 
     fn inverse(&self) -> Option<Self> {

--- a/src/fp12.rs
+++ b/src/fp12.rs
@@ -110,8 +110,8 @@ impl<'a, 'b> Mul<&'b Fp12> for &'a Fp12 {
     }
 }
 
-impl_binops_additive!(Fp12, Fp12);
-impl_binops_multiplicative!(Fp12, Fp12);
+impl_binops_additive!(Fp12, Fp12, fff::Field);
+impl_binops_multiplicative!(Fp12, Fp12, fff::Field);
 
 impl Fp12 {
     /// Constructs an element of `Fp12`.
@@ -445,7 +445,8 @@ impl Field for Fp12 {
     }
 
     fn double(&mut self) {
-        *self += *self;
+        self.0.fp6[0] = (self.c0() + self.c0()).0;
+        self.0.fp6[1] = (self.c1() + self.c1()).0;
     }
 
     fn negate(&mut self) {
@@ -453,11 +454,13 @@ impl Field for Fp12 {
     }
 
     fn add_assign(&mut self, other: &Self) {
-        *self += other;
+        self.0.fp6[0] = (self.c0() + other.c0()).0;
+        self.0.fp6[1] = (self.c1() + other.c1()).0;
     }
 
     fn sub_assign(&mut self, other: &Self) {
-        *self -= other;
+        self.0.fp6[0] = (self.c0() - other.c0()).0;
+        self.0.fp6[1] = (self.c1() - other.c1()).0;
     }
 
     fn frobenius_map(&mut self, power: usize) {
@@ -506,7 +509,7 @@ impl Field for Fp12 {
     }
 
     fn mul_assign(&mut self, other: &Self) {
-        *self *= other;
+        unsafe { blst_fp12_mul(&mut self.0, &self.0, &other.0) };
     }
 
     fn inverse(&self) -> Option<Self> {

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -129,8 +129,8 @@ impl<'a, 'b> Mul<&'b Fp2> for &'a Fp2 {
     }
 }
 
-impl_binops_additive!(Fp2, Fp2);
-impl_binops_multiplicative!(Fp2, Fp2);
+impl_binops_additive!(Fp2, Fp2, fff::Field);
+impl_binops_multiplicative!(Fp2, Fp2, fff::Field);
 
 impl Fp2 {
     /// Constructs an element of `Fp2`.
@@ -260,7 +260,7 @@ impl Field for Fp2 {
     }
 
     fn double(&mut self) {
-        *self += *self;
+        unsafe { blst_fp2_add(&mut self.0, &self.0, &self.0) };
     }
 
     fn negate(&mut self) {
@@ -268,15 +268,15 @@ impl Field for Fp2 {
     }
 
     fn add_assign(&mut self, other: &Self) {
-        *self = self.add(other);
+        unsafe { blst_fp2_add(&mut self.0, &self.0, &other.0) };
     }
 
     fn sub_assign(&mut self, other: &Self) {
-        *self = self.sub(other);
+        unsafe { blst_fp2_sub(&mut self.0, &self.0, &other.0) };
     }
 
     fn mul_assign(&mut self, other: &Self) {
-        *self = self.mul(other);
+        unsafe { blst_fp2_mul(&mut self.0, &self.0, &other.0) };
     }
 
     fn inverse(&self) -> Option<Self> {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -99,20 +99,54 @@ macro_rules! impl_binops_multiplicative_mixed {
 }
 
 macro_rules! impl_binops_additive {
-    ($lhs:ident, $rhs:ident) => {
+    ($lhs:ident, $rhs:ident, $source:path) => {
         impl_binops_additive_specify_output!($lhs, $rhs, $lhs);
 
         impl SubAssign<$rhs> for $lhs {
             #[inline]
             fn sub_assign(&mut self, rhs: $rhs) {
-                *self = &*self - &rhs;
+                <Self as $source>::sub_assign(self, &rhs);
             }
         }
 
         impl AddAssign<$rhs> for $lhs {
             #[inline]
             fn add_assign(&mut self, rhs: $rhs) {
-                *self = &*self + &rhs;
+                <Self as $source>::add_assign(self, &rhs);
+            }
+        }
+
+        impl<'b> SubAssign<&'b $rhs> for $lhs {
+            #[inline]
+            fn sub_assign(&mut self, rhs: &'b $rhs) {
+                <Self as $source>::sub_assign(self, rhs);
+            }
+        }
+
+        impl<'b> AddAssign<&'b $rhs> for $lhs {
+            #[inline]
+            fn add_assign(&mut self, rhs: &'b $rhs) {
+                <Self as $source>::add_assign(self, rhs);
+            }
+        }
+    };
+}
+
+macro_rules! impl_binops_additive_mixed {
+    ($lhs:ident, $rhs:ident, $source:path) => {
+        impl_binops_additive_specify_output!($lhs, $rhs, $lhs);
+
+        impl SubAssign<$rhs> for $lhs {
+            #[inline]
+            fn sub_assign(&mut self, rhs: $rhs) {
+                *self = &*self - rhs;
+            }
+        }
+
+        impl AddAssign<$rhs> for $lhs {
+            #[inline]
+            fn add_assign(&mut self, rhs: $rhs) {
+                <Self as $source>::add_assign_mixed(self, &rhs);
             }
         }
 
@@ -126,27 +160,27 @@ macro_rules! impl_binops_additive {
         impl<'b> AddAssign<&'b $rhs> for $lhs {
             #[inline]
             fn add_assign(&mut self, rhs: &'b $rhs) {
-                *self = &*self + rhs;
+                <Self as $source>::add_assign_mixed(self, rhs);
             }
         }
     };
 }
 
 macro_rules! impl_binops_multiplicative {
-    ($lhs:ident, $rhs:ident) => {
+    ($lhs:ident, $rhs:ident, $source:path) => {
         impl_binops_multiplicative_mixed!($lhs, $rhs, $lhs);
 
         impl MulAssign<$rhs> for $lhs {
             #[inline]
             fn mul_assign(&mut self, rhs: $rhs) {
-                *self = &*self * &rhs;
+                <Self as $source>::mul_assign(self, &rhs);
             }
         }
 
         impl<'b> MulAssign<&'b $rhs> for $lhs {
             #[inline]
             fn mul_assign(&mut self, rhs: &'b $rhs) {
-                *self = &*self * rhs;
+                <Self as $source>::mul_assign(self, rhs);
             }
         }
     };

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -320,8 +320,8 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a Scalar {
     }
 }
 
-impl_binops_additive!(Scalar, Scalar);
-impl_binops_multiplicative!(Scalar, Scalar);
+impl_binops_additive!(Scalar, Scalar, fff::Field);
+impl_binops_multiplicative!(Scalar, Scalar, fff::Field);
 
 impl fff::Field for Scalar {
     fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
@@ -356,29 +356,27 @@ impl fff::Field for Scalar {
     }
 
     fn square(&mut self) {
-        let mut raw = blst_fr::default();
-        unsafe { blst_fr_sqr(&mut raw, &self.0) }
-
-        self.0 = raw;
+        unsafe { blst_fr_sqr(&mut self.0, &self.0) }
     }
 
     fn double(&mut self) {
-        *self += *self;
+        unsafe { blst_fr_add(&mut self.0, &self.0, &self.0) }
     }
 
     fn negate(&mut self) {
         *self = -&*self;
     }
+
     fn add_assign(&mut self, other: &Self) {
-        *self += other;
+        unsafe { blst_fr_add(&mut self.0, &self.0, &other.0) };
     }
 
     fn sub_assign(&mut self, other: &Self) {
-        *self -= other;
+        unsafe { blst_fr_sub(&mut self.0, &self.0, &other.0) };
     }
 
     fn mul_assign(&mut self, other: &Self) {
-        *self *= other;
+        unsafe { blst_fr_mul(&mut self.0, &self.0, &other.0) };
     }
 
     fn inverse(&self) -> Option<Self> {


### PR DESCRIPTION
This avoids allocation, reducing the overhead of calls considerably in some cases.

benchcmp

```
 name                                               baseline ns/iter  less-allocs ns/iter  diff ns/iter   diff %  speedup
 bls12_381::bench_pairing_final_exponentiation      331,967           330,414                    -1,553   -0.47%   x 1.00
 bls12_381::bench_pairing_full                      593,836           593,938                       102    0.02%   x 1.00
 bls12_381::bench_pairing_g1_preparation            11,610            11,593                        -17   -0.15%   x 1.00
 bls12_381::bench_pairing_g2_preparation            78,455            77,944                       -511   -0.65%   x 1.01
 bls12_381::bench_pairing_miller_loop               172,600           172,185                      -415   -0.24%   x 1.00
 bls12_381::ec::g1::bench_g1_add_assign             598               594                            -4   -0.67%   x 1.01
 bls12_381::ec::g1::bench_g1_add_assign_mixed       449               474                            25    5.57%   x 0.95
 bls12_381::ec::g1::bench_g1_mul_assign             105,034           102,225                    -2,809   -2.67%   x 1.03
 bls12_381::ec::g2::bench_g2_add_assign             1,655             1,656                           1    0.06%   x 1.00
 bls12_381::ec::g2::bench_g2_add_assign_mixed       1,222             1,213                          -9   -0.74%   x 1.01
 bls12_381::ec::g2::bench_g2_mul_assign             254,318           253,135                    -1,183   -0.47%   x 1.00
 bls12_381::fp12::bench_fp12_add_assign             135               130                            -5   -3.70%   x 1.04
 bls12_381::fp12::bench_fp12_inverse                9,319             9,360                          41    0.44%   x 1.00
 bls12_381::fp12::bench_fp12_mul_assign             1,855             1,828                         -27   -1.46%   x 1.01
 bls12_381::fp12::bench_fp12_squaring               1,347             1,339                          -8   -0.59%   x 1.01
 bls12_381::fp12::bench_fp12_sub_assign             134               130                            -4   -2.99%   x 1.03
 bls12_381::fp2::bench_fp2_add_assign               16                13                             -3  -18.75%   x 1.23
 bls12_381::fp2::bench_fp2_inverse                  6,125             6,133                           8    0.13%   x 1.00
 bls12_381::fp2::bench_fp2_mul_assign               100               97                             -3   -3.00%   x 1.03
 bls12_381::fp2::bench_fp2_sqrt                     72,850            72,125                       -725   -1.00%   x 1.01
 bls12_381::fp2::bench_fp2_squaring                 69                69                              0    0.00%   x 1.00
 bls12_381::fp2::bench_fp2_sub_assign               16                14                             -2  -12.50%   x 1.14
 bls12_381::fp::bench_fp_add_assign                 10                7                              -3  -30.00%   x 1.43
 bls12_381::fp::bench_fp_from_repr                  39                39                              0    0.00%   x 1.00
 bls12_381::fp::bench_fp_into_repr                  22                22                              0    0.00%   x 1.00
 bls12_381::fp::bench_fp_inverse                    5,954             5,958                           4    0.07%   x 1.00
 bls12_381::fp::bench_fp_mul_assign                 38                35                             -3   -7.89%   x 1.09
 bls12_381::fp::bench_fp_negate                     11                10                             -1   -9.09%   x 1.10
 bls12_381::fp::bench_fp_repr_add_nocarry           5                 5                               0    0.00%   x 1.00
 bls12_381::fp::bench_fp_repr_div2                  4                 5                               1   25.00%   x 0.80
 bls12_381::fp::bench_fp_repr_mul2                  7                 4                              -3  -42.86%   x 1.75
 bls12_381::fp::bench_fp_repr_num_bits              3                 3                               0    0.00%   x 1.00
 bls12_381::fp::bench_fp_repr_sub_noborrow          7                 7                               0    0.00%   x 1.00
 bls12_381::fp::bench_fp_sqrt                       21,673            19,775                     -1,898   -8.76%   x 1.10
 bls12_381::fp::bench_fp_square                     34                35                              1    2.94%   x 0.97
 bls12_381::fp::bench_fp_sub_assign                 10                7                              -3  -30.00%   x 1.43
 bls12_381::scalar::bench_scalar_add_assign         7                 5                              -2  -28.57%   x 1.40
 bls12_381::scalar::bench_scalar_from_repr          23                23                              0    0.00%   x 1.00
 bls12_381::scalar::bench_scalar_into_repr          17                17                              0    0.00%   x 1.00
 bls12_381::scalar::bench_scalar_inverse            3,325             3,322                          -3   -0.09%   x 1.00
 bls12_381::scalar::bench_scalar_mul_assign         22                21                             -1   -4.55%   x 1.05
 bls12_381::scalar::bench_scalar_negate             8                 8                               0    0.00%   x 1.00
 bls12_381::scalar::bench_scalar_repr_add_nocarry   5                 5                               0    0.00%   x 1.00
 bls12_381::scalar::bench_scalar_repr_div2          4                 4                               0    0.00%   x 1.00
 bls12_381::scalar::bench_scalar_repr_mul2          4                 4                               0    0.00%   x 1.00
 bls12_381::scalar::bench_scalar_repr_num_bits      3                 3                               0    0.00%   x 1.00
 bls12_381::scalar::bench_scalar_repr_sub_noborrow  5                 5                               0    0.00%   x 1.00
 bls12_381::scalar::bench_scalar_sqrt               32,087            26,963                     -5,124  -15.97%   x 1.19
 bls12_381::scalar::bench_scalar_square             20                20                              0    0.00%   x 1.00
 bls12_381::scalar::bench_scalar_sub_assign         7                 5                              -2  -28.57%   x 1.40
```