### PR TITLE
Test case for m1 inversion bug.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 rustdoc-args = [ "--html-in-header", "katex-header.html" ]
 
 [dependencies]
-blst = { version = "=0.3.6", default-features = true }
+blst = { version = "=0.3.7", default-features = true }
 rand_core = "0.6"
 ff = "0.11"
 group = { version = "0.11", features = ["tests"] }
@@ -35,4 +35,3 @@ default = ["serde"]
 portable = ["blst/portable"]
 gpu = ["ec-gpu"]
 __private_bench = []
-

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1759,4 +1759,30 @@ mod tests {
             assert_eq!(b1, b2);
         }
     }
+
+    #[test]
+    fn m1_inv_bug() {
+        // This fails on aarch64-darwin.
+        let bad = Scalar::zero() - Scalar::from(7);
+
+        let inv = bad.invert().unwrap();
+        let check = inv * bad;
+        assert_eq!(Scalar::one(), check);
+    }
+    #[test]
+    fn m1_inv_bug_more() {
+        let mut bad = Vec::new();
+        for i in 1..1000000 {
+            // Ensure that a * a^-1 = 1
+            let a = Scalar::zero() - Scalar::from(i);
+            let ainv = a.invert().unwrap();
+            let check = a * ainv;
+            let one = Scalar::one();
+
+            if check != one {
+                bad.push((i, a));
+            }
+        }
+        assert_eq!(0, bad.len());
+    }
 }


### PR DESCRIPTION
Here are some test cases for a bug in scalar inversion I found to only manifest on my M1 mac. I believe this should be fixed here: https://github.com/supranational/blst/commit/4f9d5577eea182f17614492f1e703400e9223cf3.