### PR TITLE
feat(scalar): sum/product impls for scalar

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -2,9 +2,11 @@
 //! where `q = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`
 
 use core::{
+    borrow::Borrow,
     cmp,
     convert::TryInto,
     fmt,
+    iter::{Product, Sum},
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
@@ -302,6 +304,30 @@ impl MulAssign<&Scalar> for Scalar {
     #[inline]
     fn mul_assign(&mut self, rhs: &Scalar) {
         unsafe { blst_fr_mul(&mut self.0, &self.0, &rhs.0) };
+    }
+}
+
+impl<T> Sum<T> for Scalar
+where
+    T: Borrow<Scalar>,
+{
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = T>,
+    {
+        iter.fold(Scalar::zero(), |sum, x| sum + x.borrow())
+    }
+}
+
+impl<T> Product<T> for Scalar
+where
+    T: Borrow<Scalar>,
+{
+    fn product<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = T>,
+    {
+        iter.fold(Scalar::one(), |product, x| product * x.borrow())
     }
 }
 


### PR DESCRIPTION
This PR adds Sum/Product impls on Scalar

It follows from the impls on G1/G2:
https://github.com/filecoin-project/blstrs/blob/master/src/g1.rs#L264-L274
https://github.com/filecoin-project/blstrs/blob/master/src/g2.rs#L263-L273