### PR TITLE
chore: run ARM tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,10 @@ executors:
       - image: filecoin/rust:latest
     working_directory: /mnt/crate
     resource_class: 2xlarge
+  arm:
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.large
 
 restore-workspace: &restore-workspace
   attach_workspace:
@@ -106,6 +110,21 @@ jobs:
           name: Run cargo test
           command: cargo test --features portable --workspace
 
+  test_arm:
+    executor: arm
+    steps:
+      - checkout
+      - run:
+          name: Install Rust
+          command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal --default-toolchain $(cat rust-toolchain) -y
+      - run:
+          name: Run cargo test
+          command: cargo test --workspace
+      - run:
+          name: Run cargo test portable
+          command: cargo test --workspace --features portable
+
   check_gpu:
     executor: default
     steps:
@@ -192,6 +211,7 @@ workflows:
       - test_portable:
           requires:
             - cargo_fetch
+      - test_arm
       - check_gpu:
           requires:
             - cargo_fetch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,38 +21,40 @@ jobs:
       - id: msrv
         run: echo "::set-output name=msrv::$(echo $MSRV)"
 
-  linux_foreign:
-    strategy:
-      matrix:
-        include:
-          # 64-bit Linux/arm64
-          - target: aarch64-unknown-linux-gnu
-            rust: nightly
-            arch: aarch64
-
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: uraimo/run-on-arch-action@v2.1.1
-        name: Run commands
-        id: runcmd
-        with:
-          arch: aarch64
-          distro: ubuntu18.04
-
-          # Not required, but speeds up builds by storing container images in
-          # a GitHub package registry.
-          githubToken: ${{ github.token }}
-
-          install: |
-            apt-get update -q -y
-            apt-get install -q -y ocl-icd-opencl-dev curl build-essential
-            curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal --default-toolchain ${{ matrix.rust }} -y
-            source $HOME/.cargo/env
-          
-          run: |
-            $HOME/.cargo/bin/cargo test --release --target ${{ matrix.target }}
-            $HOME/.cargo/bin/cargo test --release --features portable --target ${{ matrix.target }}
+  # NOTE vmx 2022-06-14: currently doesn't work, hence run it on CircleCI
+  # for now.
+  #linux_foreign:
+  #  strategy:
+  #    matrix:
+  #      include:
+  #        # 64-bit Linux/arm64
+  #        - target: aarch64-unknown-linux-gnu
+  #          rust: nightly
+  #          arch: aarch64
+  #
+  #  runs-on: ubuntu-18.04
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - uses: uraimo/run-on-arch-action@v2.1.1
+  #      name: Run commands
+  #      id: runcmd
+  #      with:
+  #        arch: aarch64
+  #        distro: ubuntu18.04
+  #
+  #        # Not required, but speeds up builds by storing container images in
+  #        # a GitHub package registry.
+  #        githubToken: ${{ github.token }}
+  #
+  #        install: |
+  #          apt-get update -q -y
+  #          apt-get install -q -y ocl-icd-opencl-dev curl build-essential
+  #          curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal --default-toolchain ${{ matrix.rust }} -y
+  #          source $HOME/.cargo/env
+  #
+  #        run: |
+  #          $HOME/.cargo/bin/cargo test --release --target ${{ matrix.target }}
+  #          $HOME/.cargo/bin/cargo test --release --features portable --target ${{ matrix.target }}
 
   # Linux tests
   linux:


### PR DESCRIPTION
Currently tests running via GitHub Actions are killed due to invalid
memory access. Running them on CircleCI works fine.