### PR TITLE
feat: implement ec-gpu 0.2.0 traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ pairing_lib = { version = "0.22", package = "pairing" }
 subtle = "2.2.1"
 
 serde = { version = "1.0", features = ["derive"], optional = true }
-ec-gpu = { version = "0.1.0", optional = true }
+ec-gpu = { version = "0.2.0", optional = true }
 byte-slice-cast = "1.0.0"
 
 [dev-dependencies]

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -657,6 +657,13 @@ impl Fp {
 }
 
 #[cfg(feature = "gpu")]
+impl ec_gpu::GpuName for Fp {
+    fn name() -> String {
+        ec_gpu::name!()
+    }
+}
+
+#[cfg(feature = "gpu")]
 impl ec_gpu::GpuField for Fp {
     fn one() -> Vec<u32> {
         crate::u64_to_u32(&R.0.l[..])

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -291,6 +291,34 @@ impl Field for Fp2 {
     }
 }
 
+#[cfg(feature = "gpu")]
+impl ec_gpu::GpuName for Fp2 {
+    fn name() -> String {
+        ec_gpu::name!()
+    }
+}
+
+// Use `one`, `r2` and `modulus` from the sub-field.
+#[cfg(feature = "gpu")]
+impl ec_gpu::GpuField for Fp2 {
+    fn one() -> Vec<u32> {
+        <Fp as ec_gpu::GpuField>::one()
+    }
+
+    fn r2() -> Vec<u32> {
+        Fp::r2()
+    }
+
+    fn modulus() -> Vec<u32> {
+        Fp::modulus()
+    }
+
+    fn sub_field_name() -> Option<String> {
+        use ec_gpu::GpuName;
+        Some(Fp::name())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -838,6 +838,13 @@ impl PairingCurveAffine for G1Affine {
     }
 }
 
+#[cfg(feature = "gpu")]
+impl ec_gpu::GpuName for G1Affine {
+    fn name() -> String {
+        ec_gpu::name!()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::eq_op)]

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -777,6 +777,13 @@ impl PairingCurveAffine for G2Affine {
     }
 }
 
+#[cfg(feature = "gpu")]
+impl ec_gpu::GpuName for G2Affine {
+    fn name() -> String {
+        ec_gpu::name!()
+    }
+}
+
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct G2Uncompressed([u8; UNCOMPRESSED_SIZE]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,12 +94,6 @@ impl MultiMillerLoop for Bls12 {
 }
 
 #[cfg(feature = "gpu")]
-impl ec_gpu::GpuEngine for Bls12 {
-    type Scalar = Scalar;
-    type Fp = crate::fp::Fp;
-}
-
-#[cfg(feature = "gpu")]
 fn u64_to_u32(limbs: &[u64]) -> Vec<u32> {
     limbs
         .iter()

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -679,6 +679,13 @@ impl Scalar {
 }
 
 #[cfg(feature = "gpu")]
+impl ec_gpu::GpuName for Scalar {
+    fn name() -> String {
+        ec_gpu::name!()
+    }
+}
+
+#[cfg(feature = "gpu")]
 impl ec_gpu::GpuField for Scalar {
     fn one() -> Vec<u32> {
         crate::u64_to_u32(&R.0.l[..])


### PR DESCRIPTION
With implementing the ec-gpu traits, the types can be used with
algorithms that run on the GPU.

BREAKING CHANGE: the traits in ec-gpu 0.2.0 changed

There is no `GpuEngine` trait anymore and the `GpuName` trait was
introduced.