### PR TITLE
fix: also implement `GpuName` for `Fp6` and `Fp12`

### DIFF
--- a/src/fp12.rs
+++ b/src/fp12.rs
@@ -303,6 +303,13 @@ impl Fp12 {
     }
 }
 
+#[cfg(feature = "gpu")]
+impl ec_gpu::GpuName for Fp12 {
+    fn name() -> String {
+        ec_gpu::name!()
+    }
+}
+
 // non_residue^((modulus^i-1)/6) for i=0,...,11
 const FROBENIUS_COEFF_FP12_C1: [blst_fp2; 12] = [
     // Fp2(u + 1)**(((q^0) - 1) / 6)

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -401,6 +401,13 @@ impl Fp6 {
     }
 }
 
+#[cfg(feature = "gpu")]
+impl ec_gpu::GpuName for Fp6 {
+    fn name() -> String {
+        ec_gpu::name!()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Implement `GpuName` for all `ff::Field`s in this crate. This way
`ec_gpu::GpuName` can be added as trait bound to `ff::Field`.