### PR TITLE
Revert "public R and Zero constants"

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -31,12 +31,12 @@ const MODULUS_REPR: [u8; 48] = [
     0xd7, 0xac, 0x4b, 0x43, 0xb6, 0xa7, 0x1b, 0x4b, 0x9a, 0xe6, 0x7f, 0x39, 0xea, 0x11, 0x01, 0x1a,
 ];
 
-pub const ZERO: Fp = Fp(blst_fp {
+const ZERO: Fp = Fp(blst_fp {
     l: [0, 0, 0, 0, 0, 0],
 });
 
 /// R = 2^384 mod p
-pub const R: Fp = Fp(blst_fp {
+const R: Fp = Fp(blst_fp {
     l: [
         0x7609_0000_0002_fffd,
         0xebf4_000b_c40c_0002,


### PR DESCRIPTION
This reverts commit da7e03873802316f4544107fa28b174f6261d809.

Sorry by mistake while playing with blstrs I pushed on main repo... on master. No big deal changes but I thought I'd revert it here and explain.

Pushing on master probably should be disabled tbh for the repo, or enforced via PR at least.