### PR TITLE
added benchmarks for G_T

### DIFF
--- a/benches/bls12_381/ec.rs
+++ b/benches/bls12_381/ec.rs
@@ -167,3 +167,56 @@ mod g2 {
         });
     }
 }
+
+mod gt {
+    use rand_core::SeedableRng;
+    use rand_xorshift::XorShiftRng;
+
+    use blstrs::*;
+    use ff::Field;
+    use group::Group;
+
+    #[bench]
+    fn bench_gt_add_assign(b: &mut ::test::Bencher) {
+        const SAMPLES: usize = 1000;
+
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
+            0xbc, 0xe5,
+        ]);
+
+        let v: Vec<(Gt, Gt)> = (0..SAMPLES)
+            .map(|_| (Gt::random(&mut rng), Gt::random(&mut rng)))
+            .collect();
+
+        let mut count = 0;
+        b.iter(|| {
+            let mut tmp = v[count].0;
+            tmp += v[count].1;
+            count = (count + 1) % SAMPLES;
+            tmp
+        });
+    }
+
+    #[bench]
+    fn bench_gt_mul_assign(b: &mut ::test::Bencher) {
+        const SAMPLES: usize = 1000;
+
+        let mut rng = XorShiftRng::from_seed([
+            0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06,
+            0xbc, 0xe5,
+        ]);
+
+        let v: Vec<(Gt, Scalar)> = (0..SAMPLES)
+            .map(|_| (Gt::random(&mut rng), Scalar::random(&mut rng)))
+            .collect();
+
+        let mut count = 0;
+        b.iter(|| {
+            let mut tmp = v[count].0;
+            tmp *= v[count].1;
+            count = (count + 1) % SAMPLES;
+            tmp
+        });
+    }
+}


### PR DESCRIPTION
Added some missing benchmarks for $\mathbb{G}_T$ operations.

**Note:** The `rust_toolchain` file and the hardcoded version in `Cargo.toml` caused problems for me. However, I can revert those changes if need be.