### PR TITLE
feat: add support for zeroize in scalar type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ ff = "0.13"
 group = { version = "0.13", features = ["tests"] }
 pairing_lib = { version = "0.23", package = "pairing" }
 subtle = "2.2.1"
+zeroize = "1.8.2"
 
 serde = { version = "1.0", features = ["derive"], optional = true }
 ec-gpu = { version = "0.2.0", optional = true }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -9,7 +9,6 @@ use core::{
     iter::{Product, Sum},
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
-use std::{ptr, sync::atomic};
 
 use blst::*;
 use byte_slice_cast::AsByteSlice;
@@ -677,16 +676,8 @@ impl Scalar {
 }
 
 impl Zeroize for Scalar {
-    /// Implementation based on the zeroize crate, which guarantees the value
-    /// becomes 0 when the function is called by ensuring the compiler does not
-    /// optimize the function away
-    /// See <https://docs.rs/zeroize/latest/zeroize/#what-guarantees-does-this-crate-provide>
-    /// for more details
     fn zeroize(&mut self) {
-        unsafe {
-            ptr::write_volatile(&mut self.0, blst_fr { l: [0u64; 4] });
-        }
-        atomic::compiler_fence(atomic::Ordering::SeqCst);
+        self.0.l.zeroize();
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -9,12 +9,14 @@ use core::{
     iter::{Product, Sum},
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
+use std::{ptr, sync::atomic};
 
 use blst::*;
 use byte_slice_cast::AsByteSlice;
 use ff::{Field, FieldBits, PrimeField, PrimeFieldBits};
 use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+use zeroize::Zeroize;
 
 /// Represents an element of the scalar field $\mathbb{F}_q$ of the BLS12-381 elliptic
 /// curve construction.
@@ -671,6 +673,20 @@ impl Scalar {
     #[inline]
     pub fn square_assign(&mut self) {
         unsafe { blst_fr_sqr(&mut self.0, &self.0) };
+    }
+}
+
+impl Zeroize for Scalar {
+    /// Implementation based on the zeroize crate, which guarantees the value
+    /// becomes 0 when the function is called by ensuring the compiler does not
+    /// optimize the function away
+    /// See <https://docs.rs/zeroize/latest/zeroize/#what-guarantees-does-this-crate-provide>
+    /// for more details
+    fn zeroize(&mut self) {
+        unsafe {
+            ptr::write_volatile(&mut self.0, blst_fr { l: [0u64; 4] });
+        }
+        atomic::compiler_fence(atomic::Ordering::SeqCst);
     }
 }
 


### PR DESCRIPTION
This PR adds support for zeroizing the Scalar values following the `zeroize` crate. Unfortunately the underlying type of the Scalar type in this crate `blst_fr` does not implement the `Zeroize` trait, so the PR implements it manually using unsafe code. 

If the underlying type was `blst_scalar`, the task would have been trivial because that type does implement `Zeroize`. I know the difference between these two was discussed in the past: https://github.com/filecoin-project/blstrs/issues/10. Just wanted to mention that the lack of zeroize upstream for `blst_fr` seems to point to the fact that `blst_scalar` should have been used instead.