### PR TITLE
Avoids unnecessary zeroing of memory

### DIFF
--- a/src/g2.rs
+++ b/src/g2.rs
@@ -4,6 +4,7 @@ use core::{
     borrow::Borrow,
     fmt,
     iter::Sum,
+    mem::MaybeUninit,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
@@ -752,8 +753,12 @@ impl From<G2Affine> for G2Prepared {
                 infinity: true,
             }
         } else {
-            let mut lines = vec![blst_fp6::default(); 68];
-            unsafe { blst_precompute_lines(lines.as_mut_ptr(), &affine.0) }
+            let mut lines = Vec::with_capacity(68);
+            let uninit_lines: &mut [MaybeUninit<blst_fp6>] = lines.spare_capacity_mut();
+            unsafe {
+                blst_precompute_lines(uninit_lines.as_mut_ptr().cast(), &affine.0);
+                lines.set_len(68);
+            }
             G2Prepared {
                 lines,
                 infinity: false,

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -1,5 +1,8 @@
 use crate::{fp12::Fp12, G1Affine, G2Affine, Gt};
-use core::ops::{Add, AddAssign};
+use core::{
+    mem::MaybeUninit,
+    ops::{Add, AddAssign},
+};
 use ff::Field;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -21,14 +24,13 @@ macro_rules! impl_pairing {
         /// Aggregate pairings efficiently.
         #[derive(Debug)]
         pub struct $name {
-            v: Box<[u64]>,
+            v: Box<[MaybeUninit<u64>]>,
         }
 
         impl $name {
             pub fn new(hash_or_encode: bool, dst: &[u8]) -> Self {
-                let v: Vec<u64> = vec![0; unsafe { blst_pairing_sizeof() } / 8];
                 let mut obj = Self {
-                    v: v.into_boxed_slice(),
+                    v: Box::<[u64]>::new_uninit_slice(unsafe { blst_pairing_sizeof() } / 8),
                 };
                 obj.init(hash_or_encode, dst);
                 obj
@@ -39,11 +41,11 @@ macro_rules! impl_pairing {
             }
 
             fn ctx(&mut self) -> *mut blst_pairing {
-                self.v.as_mut_ptr() as *mut blst_pairing
+                self.v.as_mut_ptr().cast()
             }
 
             fn const_ctx(&self) -> *const blst_pairing {
-                self.v.as_ptr() as *const blst_pairing
+                self.v.as_ptr().cast()
             }
 
             pub fn aggregate(
@@ -131,8 +133,8 @@ pub fn unique_messages(msgs: &[&[u8]]) -> bool {
         return msgs[0] != msgs[1];
     }
 
-    let mut v: Vec<u64> = vec![0; unsafe { blst_uniq_sizeof(n_elems) } / 8];
-    let ctx = v.as_mut_ptr() as *mut blst_uniq;
+    let mut v = Box::<[u64]>::new_uninit_slice(unsafe { blst_uniq_sizeof(n_elems) } / 8);
+    let ctx = v.as_mut_ptr().cast();
 
     unsafe { blst_uniq_init(ctx) };
 


### PR DESCRIPTION
I found a few places where the library is allocating memory and zeroing it only to overwrite the memory right away.  The zeroing of memory is not necessary and only degrades performance.

Further, I believe that `vec![...; N]` would invoke `calloc` which goes straight to the kernel without using the configured memory allocator.  This can be detrimental for some use cases.


This PR updates these places to use `MaybeUninit` API which avoids unnecessary initialization of memory.  And now the memory allocations should be using `malloc` so will go to malloc.